### PR TITLE
Ensure AWS secret variables are defined

### DIFF
--- a/shared/npm-install.sh
+++ b/shared/npm-install.sh
@@ -55,6 +55,8 @@ ARGV_S3_BUCKET=""
 ARGV_PREFIX=""
 ARGV_PRODUCTION=false
 ARGV_DONT_UPLOAD_CACHE=false
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
 
 while getopts ":b:r:t:s:n:l:a:x:pi" option; do
   case $option in


### PR DESCRIPTION
This prevents failures due to the nounset option being enabled.

Fixes https://github.com/balena-io/scripts/issues/7