### PR TITLE
Add should-store script that checks if package.json sets private: true

### DIFF
--- a/npm/should-store.sh
+++ b/npm/should-store.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+ARGV_DIRECTORY="$1"
+set -u
+
+[[ "${DEBUG}" == "false" ]] || set -x
+
+pushd $ARGV_DIRECTORY
+
+# If private is true in package.json this means the package
+# is not meant to be published at all.
+[[ "$(jq '.private' package.json)" == "true" ]] && exit 1
+
+# If we made it through the checks, exit successfully
+exit 0

--- a/npm/store.sh
+++ b/npm/store.sh
@@ -8,10 +8,6 @@ set -u
 
 pushd $ARGV_DIRECTORY
 
-# If private is true in package.json this means the package
-# is not meant to be published at all.
-[[ "$(jq '.private' package.json)" == "true" ]] && exit 1
-
 headBranch=$(jq -r '.head_branch' .git/.version)
 org=$(jq -r '.base_org' .git/.version)
 repo=$(jq -r '.base_repo' .git/.version)

--- a/shared/is-npm.sh
+++ b/shared/is-npm.sh
@@ -15,6 +15,11 @@ should_run="$(${HERE}/scripts/shared/resinci-read.sh \
 
 [[ "${should_run}" == "true" ]] && exit
 [[ "${should_run}" == "false" ]] && exit 1
+project_type="$(yq read repo.yml 'type')"
+# Explicitly check for electron packages as they appear as npm ones
+[[ "$project_type" == "electron" ]] && exit 1
+# Explicitly check for generic packages as they might appear as npm ones
+[[ "$project_type" == "generic" ]] && exit 1
 [[ -f package.json ]] || exit 1
 
 # If we made it through the checks, exit successfully


### PR DESCRIPTION
Also exclude electron applications from is-npm checks as those will meet
all the requirements to qualify as an npm project

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@balena.io>