### PR TITLE
Don't specify a default "files" section for electron-builder

### DIFF
--- a/electron/electron-builder.json
+++ b/electron/electron-builder.json
@@ -1,12 +1,6 @@
 {
   "npmRebuild": true,
   "nodeGypRebuild": true,
-  "files": [
-    "lib",
-    "build/**/*.node",
-    "assets/icon.png",
-    "node_modules/**/*"
-  ],
   "mac": {
     "icon": "assets/icon.icns"
   },


### PR DESCRIPTION
Use the electron-builder defaults or add it to .resinci.json in your
project.

Change-type: patch