### PR TITLE
Fix libpango deb package name for electron

### DIFF
--- a/electron/electron-builder.json
+++ b/electron/electron-builder.json
@@ -62,7 +62,7 @@
       "libnotify4",
       "libnspr4",
       "libnss3",
-      "libpango1.0-0",
+      "libpango1.0-0 | libpango-1.0-0",
       "libstdc++6",
       "libx11-6",
       "libxcomposite1",


### PR DESCRIPTION
Change-type: patch