### PR TITLE
Update base-branch check to check if branch is declared as ESR rather

### DIFF
--- a/ci-checks/should-build-branch.sh
+++ b/ci-checks/should-build-branch.sh
@@ -17,12 +17,12 @@ number=$(jq -r '.number' .git/.version)
 # If the PR is targeting master then we exit with success
 [[ "${base}" == "master" ]] && exit 0
 
-# Otherwise we check if a Backport footer exists, and fail if not
+# Check if the branch is or is being declared as ESR
+esr="$(yq r repo.yml 'esr.version')"
+[[ "${esr}" != "null" ]] && exit 0
+
+# Otherwise we check if a meta footer exists, and fail if not
 COMMITS=$(find-commits parsed -r ${baseRepo} -o ${baseOrg} -n ${number})
-
-IS_BACKPORT_COMMIT=$(echo ${COMMITS} | jq -c '[.[].footers] | add' | jq 'map(select(. | startswith("Backport-to:"))) | length > 0')
-
-[[ ${IS_BACKPORT_COMMIT} == "true" ]] && exit 0
 
 IS_META_COMMIT=$(echo ${COMMITS} | jq -c '[.[].footers] | add' | jq 'map(select(. | startswith("Change-type:"))) | length > 0 and all(contains("none"))')
 


### PR DESCRIPTION
than expect only backport commits

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>