### PR TITLE
Use `egrep` rather than `/usr/bin/egrep` for resilience to path changes

### DIFF
--- a/ci-checks/check-commits.sh
+++ b/ci-checks/check-commits.sh
@@ -10,7 +10,7 @@ set -u
 apk add --no-cache grep
 
 author=$(cd ${ARGV_DIRECTORY} && git show -s --format=%aN)
-if echo "$author" | /usr/bin/egrep -zoi 'resin-io(-\w+)?-versionbot'; then
+if echo "$author" | egrep -zoi 'resin-io(-\w+)?-versionbot'; then
   echo "User is a versionbot; skipping validation"
   exit 0
 fi

--- a/ci-checks/check-license.sh
+++ b/ci-checks/check-license.sh
@@ -21,6 +21,6 @@ if ls license*; then
   apk add --no-cache grep > /dev/null
   echo "Running regex test" 1>&2
   # Only fail if license is present but not one of the specified ones
-  /usr/bin/egrep -zoi '(apache.*2.0|affero general public license)' license*
+  egrep -zoi '(apache.*2.0|affero general public license)' license*
   exit
 fi

--- a/npm/store.sh
+++ b/npm/store.sh
@@ -37,7 +37,7 @@ popd
 
 pushd $ARGV_DIRECTORY
 
-if /usr/bin/egrep '(preversion|postversion|prepare|prepack|postpack|publish)' package.json; then
+if egrep '(preversion|postversion|prepare|prepack|postpack|publish)' package.json; then
   npm install
 fi
 


### PR DESCRIPTION
And the path has indeed changed from `/usr/bin/egrep` to `/bin/egrep` with the updated alpine in newer nodejs images